### PR TITLE
ci: Disable actions for non master branches

### DIFF
--- a/.github/workflows/check_commit.yaml
+++ b/.github/workflows/check_commit.yaml
@@ -2,15 +2,21 @@
 name: "Check commit"
 # yamllint disable-line rule:truthy
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   commit_check:
-    name: Run check commit
+    name: Check commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: commit-check/commit-check-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run conventional commit checks
+        uses: commit-check/commit-check-action@v1
         with:
           message: true
           branch: false

--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -2,14 +2,19 @@
 name: "Check mds for broken links"
 # yamllint disable-line rule:truthy
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   broken_link_check:
-    name: Run check links
+    name: Check orphan links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run Link Checker
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -2,11 +2,15 @@
 name: "markdownlint"
 # yamllint disable-line rule:truthy
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   lint:
-    name: Run markdownlint-cli
+    name: Check markdown with markdownlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,10 +2,15 @@
 name: shellcheck
 # yamllint disable-line rule:truthy
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   lint:
+    name: Check shell scripts with shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/yamlfmt.yaml
+++ b/.github/workflows/yamlfmt.yaml
@@ -2,11 +2,15 @@
 name: "yamlfmt"
 # yamllint disable-line rule:truthy
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   format_check:
-    name: Run yamlfmt
+    name: Check yaml with yamlfmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -2,11 +2,15 @@
 name: "yamllint"
 # yamllint disable-line rule:truthy
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   lint:
-    name: Run yamllint
+    name: Check yaml with yamllint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description

This PR implements #225, only github actions change. It disable actions for non-master and leaves it only for master pushes and PR.

## Type of Change

<!--
Please check the relevant option by placing an "x" inside the brackets [x].
-->

- [ ] Bug fix
- [x] New feature/configuration
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!-- 
Ensure that your PR adheres to the following requirements.
-->

- [x] I have read and followed the ![CONTRIBUTING.md](CONTRIBUTING.md).
- [x] The code or configuration is properly tested.
- [x] All changes are documented in the appropriate `.md` file or within comments.
- [x] No configuration files (e.g., `.bashrc`, `.zshrc`, `sway/config`) are
  broken or misconfigured.
- [x] I have manually verified that all new configurations work as expected.
- [x] I have updated the README or documentation if necessary.
- [x] I have considered backward compatibility for existing setups.
- [x] I have linted and formatted my code/config files if applicable.

## Testing

<!-- 
Please describe how you tested the changes you made. 
Example: Tested on Arch Linux with Sway and Zsh.
-->

## Screenshots (if applicable)

<!-- 
If the changes involve visual updates (e.g., i3 or Sway configuration), include screenshots.
-->

## Additional Notes

<!-- 
Add any other information you think is important or relevant to this PR.
-->
